### PR TITLE
Added additional printer drivers.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,14 @@ LABEL description="AIRPRINT FROM SYNOLOGY DSM 7 (HP, SAMSUNG, ETC)"
 
 RUN apt-get update && apt-get install -y \
 	locales \
+	cups-filters \
+	printer-driver-all \
+	printer-driver-cups-pdf \
+	printer-driver-foo2zjs \
+	foomatic-db-compressed-ppds \
+	openprinting-ppds \
+	hpijs-ppds \
+	hp-ppd \
 	brother-lpr-drivers-extra brother-cups-wrapper-extra \
 	printer-driver-splix \
 	printer-driver-gutenprint \


### PR DESCRIPTION
I couldn't get this docker image to work with my FX printer until I loaded the drivers that the `cups-docker` (https://github.com/anujdatar/cups-docker/blob/main/Dockerfile) image contained. I probably didn't need to load them all but others might benefit from the extra drivers also.